### PR TITLE
Add prefixes to make tags less mysterious in ECR

### DIFF
--- a/roles/aws-ecr-push-post/README.rst
+++ b/roles/aws-ecr-push-post/README.rst
@@ -1,8 +1,15 @@
 Push docker images into ECR on post
 
-This tags images in ECR with `zuul.build`, `zuul.pipeline`, and `zuul.newrev`,
-which is useful for post commit jobs. See `aws-ecr-push` for the lower level
-role used to do so.
+This tags images in ECR with values from `zuul.build`, `zuul.pipeline`, and
+`zuul.newrev`, or `zuul.change`, depending on the trigger type. It will prefix
+each tag with the respective zuul attribute name and a '_'. So if the build is
+`12345`, the pipeline is `post`, and `newrev` is `012356789abcdef`, the
+specified image will be tagged `build_12345`, `pipeline_post` and
+`newrev_0123456789abcdef`.
+
+As its name implies, this is most useful for post commit jobs, though
+`zuul.change` being the fallback, it can be used in a gate job as well.. See
+`aws-ecr-push` for the lower level role used to do the pushing.
 
 **Role Variables**
 

--- a/roles/aws-ecr-push-post/defaults/main.yaml
+++ b/roles/aws-ecr-push-post/defaults/main.yaml
@@ -6,7 +6,7 @@ aws_ecr_push_post_lifecycle_policy:
       selection:
         tagStatus: tagged
         tagPrefixList:
-          - "{{ zuul.pipeline }}"
+          - "pipeline_{{ zuul.pipeline }}"
         countType: imageCountMoreThan
         countNumber: 50
       action:

--- a/roles/aws-ecr-push-post/meta/main.yaml
+++ b/roles/aws-ecr-push-post/meta/main.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - role: aws-ecr-push
-  aws_ecr_push_tag: "{{ zuul.build }}"
+  aws_ecr_push_tag: "build_{{ zuul.build }}"
 - role: aws-ecr-push
-  aws_ecr_push_tag: "{{ zuul.pipeline }}"
+  aws_ecr_push_tag: "pipeline_{{ zuul.pipeline }}"
 - role: aws-ecr-push
-  aws_ecr_push_tag: "{{ zuul.newrev|default(zuul.change) }}"
+  aws_ecr_push_tag: "{%- if zuul.newrev is defined %}newrev_{{ zuul.newrev }}{%- else -%}change_{{ zuul.change }}{%- endif -%}"


### PR DESCRIPTION
Before we'd just get some random strings and a pipeline name.