### PR TITLE
Refactoring aws-ecr-push-post and co for k8s

### DIFF
--- a/roles/aws-ecr-push-post/meta/main.yaml
+++ b/roles/aws-ecr-push-post/meta/main.yaml
@@ -1,7 +1,6 @@
 dependencies:
 - role: aws-ecr-push
-  aws_ecr_push_tag: "build_{{ zuul.build }}"
-- role: aws-ecr-push
-  aws_ecr_push_tag: "pipeline_{{ zuul.pipeline }}"
-- role: aws-ecr-push
-  aws_ecr_push_tag: "{%- if zuul.newrev is defined %}newrev_{{ zuul.newrev }}{%- else -%}change_{{ zuul.change }}{%- endif -%}"
+  aws_ecr_push_tag:
+    - build_{{ zuul.build }}
+    - pipeline_{{ zuul.pipeline }}
+    - "{%- if zuul.newrev is defined %}newrev_{{ zuul.newrev }}{%- else -%}change_{{ zuul.change }}{%- endif -%}"

--- a/roles/aws-ecr-push/README.rst
+++ b/roles/aws-ecr-push/README.rst
@@ -8,6 +8,9 @@ Assumes docker is installed, and by default, that there is an unprivileged
 user named `build` that has permissions to the docker socket. See `docker-build-pre`
 for an example of how to set a box up for this role to work properly.
 
+This role will record all of the repos it has touched in a variable,
+`aws_ecr_push_repos`.
+
 **Role Variables**
 
 .. zuul:rolevar:: aws_ecr_push_region

--- a/roles/aws-ecr-push/tasks/main.yaml
+++ b/roles/aws-ecr-push/tasks/main.yaml
@@ -7,6 +7,6 @@
     tag: "{{ aws_ecr_push_tag }}"
   register: aws_ecr_push_result
 
-- name: Save image repo
-  set_fact:
-    aws_ecr_push_repos: "{{ aws_ecr_push_repos|default({}).update(aws_ecr_push_result.repos)}}"
+- name: Show push results
+  debug:
+    var: aws_ecr_push_result

--- a/roles/aws-ecr-push/tasks/main.yaml
+++ b/roles/aws-ecr-push/tasks/main.yaml
@@ -5,3 +5,8 @@
     region: "{{ aws_ecr_push_region }}"
     image: "{{ aws_ecr_push_image }}"
     tag: "{{ aws_ecr_push_tag }}"
+  register: aws_ecr_push_result
+
+- name: Save image repo
+  set_fact:
+    aws_ecr_push_repos: "{{ aws_ecr_push_repos|default({}).update(aws_ecr_push_result.repos)}}"


### PR DESCRIPTION
Need to be able to know what the image: refs in k8s objects are, so we need to
save those off.