### PR TITLE
Add a line mode to slack-notify and default to it

### DIFF
--- a/roles/slack-notify/defaults/main.yaml
+++ b/roles/slack-notify/defaults/main.yaml
@@ -9,3 +9,6 @@ slack_notify_username: Zuul
 slack_notify_normal_color: '#439FE0' # A nice calm blue
 slack_notify_success_emoji: ':thumbsup_all:'
 slack_notify_failure_emoji: ':face_palm:'
+slack_notify_msg: "{{ omit }}"
+# Set to 'attachments' to get a more vertical, informative message
+slack_notify_appearance: line

--- a/roles/slack-notify/tasks/main.yaml
+++ b/roles/slack-notify/tasks/main.yaml
@@ -42,6 +42,7 @@
         short: true
 
 - name: Create attachments
+  when: slack_notify_appearance == 'attachments'
   set_fact:
     slack_notify_attachments:
       - fallback: "{{ slack_notify_text }}"
@@ -50,9 +51,16 @@
         color: "{{ slack_notify_color }}"
         fields: "{{ slack_notify_fields }}"
 
+- name: Create single line message
+  when: slack_notify_appearance == 'line'
+  set_fact:
+    slack_notify_msg: "{{ slack_notify_text }} <{{slack_notify_zuul_url}}/build/{{zuul.build}}|{{zuul.build}}>"
+
 - name: Send a notification to slack
+  run_once: true
   slack:
-    attachments: "{{ slack_notify_attachments }}"
+    attachments: "{{ slack_notify_attachments|default(omit) }}"
+    msg: "{{ slack_notify_msg|default(omit) }}"
     token: "{{ slack_notify_token }}"
     channel: "{{ item }}"
     icon_url: "{{ slack_notify_icon }}"


### PR DESCRIPTION
The attachments mode is nice and informative, but it is also super
vertical, which is not what we want.