### PR TITLE
The aws-ecr-push role fails with multiple images

### DIFF
--- a/roles/aws-ecr-push-post/tasks/main.yaml
+++ b/roles/aws-ecr-push-post/tasks/main.yaml
@@ -1,7 +1,8 @@
-- name: Ensure lifecycel policy is set
+- name: Ensure lifecycle policy is set
   become: true
   become_user: "{{ aws_ecr_push_user }}"
   gm_ecs_ecr:
     region: "{{ aws_ecr_push_region }}"
-    name: "{{ aws_ecr_push_image }}"
+    name: "{{ item }}"
     lifecycle_policy: "{{ aws_ecr_push_post_lifecycle_policy }}"
+  loop: "{{ aws_ecr_push_image }}"

--- a/roles/aws-ecr-push/library/ecr_push.py
+++ b/roles/aws-ecr-push/library/ecr_push.py
@@ -32,9 +32,10 @@ def run(result, module):
         if module.check_mode:
             repo_objects[m_repo] = None
         else:
-            repo_objects[m_repo] = client.create_repository(repositoryName=m_repo)
+            repo_objects[m_repo] = client.create_repository(repositoryName=m_repo)['repository']
     if missing_repos:
         result['changed'] = True
+    result['push_results'] = []
     for image, repo in repo_objects.items():
         # Now get the url and auth token
         if repo:
@@ -62,7 +63,6 @@ def run(result, module):
                 tags = module.params['tag']
             else:
                 tags = [None]
-            result['push_results'] = []
             for tag in tags:
                 if tag:
                     kwa['tag'] = tag
@@ -76,7 +76,10 @@ def run(result, module):
                             module.fail_json(msg=this_result['error'])
                 if tag:
                     if 'tags' in result:
-                        result['tags'][image].append(tag)
+                        if image in result['tags']:
+                            result['tags'][image].append(tag)
+                        else:
+                            result['tags'][image] = [tag]
                     else:
                         result['tags'] = {image: [tag]}
                 result['changed'] = True

--- a/tests/aws-ecr/run.yaml
+++ b/tests/aws-ecr/run.yaml
@@ -4,11 +4,16 @@
     - role: docker-build
       docker_build_image_tag: test-aws-ecr
       docker_build_src_dir: "{{ zuul.project.src_dir }}/tests/aws-ecr/docker"
+    - role: docker-build
+      docker_build_image_tag: test-aws-ecr-2
+      docker_build_src_dir: "{{ zuul.project.src_dir }}/tests/aws-ecr/docker"
 
 - name: Push to ecr
   hosts: all
   become: true
   roles:
     - role: aws-ecr-push-post
-      aws_ecr_push_image: test-aws-ecr
+      aws_ecr_push_image:
+        - test-aws-ecr
+        - test-aws-ecr-2
       aws_ecr_push_region: us-west-2


### PR DESCRIPTION
This should fix it so that it won't fail on the second image.