### PR TITLE
Add trailing / to zuul_log_path in result

### DIFF
--- a/roles/upload-logs-s3/tasks/main.yaml
+++ b/roles/upload-logs-s3/tasks/main.yaml
@@ -40,7 +40,7 @@
   zuul_return:
     data:
       zuul:
-        log_url: "{{ zuul_log_bucket_base_url }}/{{ zuul_log_path }}"
+        log_url: "{{ zuul_log_bucket_base_url }}/{{ zuul_log_path }}/"
   when: upload_results is defined
   tags:
     # Avoid "no action detected in task" linter error


### PR DESCRIPTION
Usually webservers will redirect this, but it's not 100%.
private_s3_httpd, for instance, has trouble with this.