### PR TITLE
Register a result for aws_ecr_promote

### DIFF
--- a/roles/aws-ecr-promote/tasks/main.yaml
+++ b/roles/aws-ecr-promote/tasks/main.yaml
@@ -6,3 +6,4 @@
     image: "{{ aws_ecr_promote_image }}"
     from: "change_{{ zuul.change }}"
     to: pipeline_{{ zuul.pipeline }}
+  register: aws_ecr_promote


### PR DESCRIPTION
This way we can find the repo URLs we just promoted.