### PR TITLE
Fix ecr_retag from aws-ecr-promote

### DIFF
--- a/roles/aws-ecr-promote/library/ecr_retag.py
+++ b/roles/aws-ecr-promote/library/ecr_retag.py
@@ -45,13 +45,17 @@ def run(result, module):
             (user, password) = token.decode('ascii').split(':', 2)
             auth = (user, password)
             repo_url = "https://{}".format(repo['repositoryUri'])
+            if repo_url.startswith('https://'):
+                image_ref = repo_url.split('https://')[1]
+            else:
+                image_ref = repo_url
+            if 'repos' in result:
+                result['repos'][image] = image_ref
+            else:
+                result['repos'] = {image: image_ref}
             # The url is the pull URI, but we want the base registry URI so we
             # can talk to the registry v2 API
             repo_url = repo_url.rsplit('/', 1)[0]
-            if 'repos' in result:
-                result['repos'][image] = repo_url
-            else:
-                result['repos'] = {image: repo_url}
             # Fetch manifest for from token
             from_tag = module.params['from']
             manifest = session.get("{uri}/v2/{image}/manifests/{tag}".format(


### PR DESCRIPTION
This module had a few bugs that weren't apparent at first.

First, the
image refs in the 'repos' item are expected to be image refs for
Kubernetes to pull, so they can't start with https://.

Second, the ref was being pulled after it had the image name stripped
off, resulting in double-plus-ungood broken image refs.