### PR TITLE
Split aws-kubectl and add upstream kubectl

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -8,8 +8,10 @@
       jobs:
         - test-pip-and-virtualenv
         - test-git-crypt
+        - test-install-kubectl
     gate:
       jobs:
         - test-pip-and-virtualenv
         - test-git-crypt
+        - test-install-kubectl
         - test-aws-ecr

--- a/.zuul.d/test-jobs.yaml
+++ b/.zuul.d/test-jobs.yaml
@@ -12,3 +12,14 @@
     final: true
     protected: true
     run: tests/git-crypt/run.yaml
+
+- job:
+    parent: gm-base
+    name: test-install-kubectl
+    run: tests/k8s/run.yaml
+    final: true
+    protected: true
+    nodeset:
+      nodes:
+        - label: ubuntu1804-micro
+          name: builder

--- a/roles/aws-kubectl/meta/main.yaml
+++ b/roles/aws-kubectl/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - install-aws-kubectl

--- a/roles/aws-kubectl/tasks/main.yaml
+++ b/roles/aws-kubectl/tasks/main.yaml
@@ -1,15 +1,3 @@
-- name: Install cli tools
-  become: true
-  get_url:
-    url: "{{ item.url }}"
-    dest: "{{ item.dest }}"
-    mode: "0755"
-  loop:
-    - url: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
-      dest: /usr/bin/aws-iam-authenticator
-    - url: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl
-      dest: /usr/bin/kubectl
-
 - name: Make .kube
   file:
     path: ~/.kube

--- a/roles/install-aws-kubectl/tasks/main.yaml
+++ b/roles/install-aws-kubectl/tasks/main.yaml
@@ -1,0 +1,11 @@
+- name: Install cli tools
+  become: true
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+    mode: "0755"
+  loop:
+    - url: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+      dest: /usr/bin/aws-iam-authenticator
+    - url: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl
+      dest: /usr/bin/kubectl

--- a/roles/install-kubectl/tasks/main.yaml
+++ b/roles/install-kubectl/tasks/main.yaml
@@ -1,0 +1,16 @@
+- name: Grab version with curl
+  when: kubectl_version is not defined
+  command: curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
+  changed_when: false
+  register: kubectl_curl
+
+- name: Extract version
+  when: kubectl_curl is defined
+  set_fact:
+    kubectl_version: "{{ kubectl_curl.stdout_lines[0] }}"
+
+- name: Download kubectl
+  get_url:
+    url: https://storage.googleapis.com/kubernetes-release/release/{{ kubectl_version }}/bin/linux/amd64/kubectl
+    dest: /usr/bin/kubectl
+    mode: '0755'

--- a/tests/k8s/run.yaml
+++ b/tests/k8s/run.yaml
@@ -1,0 +1,10 @@
+- name: Install kubectl
+  hosts: all
+  become: true
+  roles:
+    - install-kubectl
+
+- name: Sanity check
+  hosts: all
+  tasks:
+    - command: kubectl version --client=true


### PR DESCRIPTION
This way we can get the right version of kubectl for our objects, but
don't need the AWS specific details. Useful for minikube testing of our
k8s objects.

Once we get off EKS we will probably want upstream kubectl. Certainly
for minikube testing we need it, as version mismatch results in errors
for kubectl.