### PR TITLE
Ensure latest on python3-distutils

### DIFF
--- a/roles/pip-and-virtualenv/tasks/main.yaml
+++ b/roles/pip-and-virtualenv/tasks/main.yaml
@@ -1,7 +1,9 @@
 - name: Install distutils
   become: true
-  package:
+  apt:
     name: python3-distutils
+    state: latest
+    update_cache: yes
 
 - name: Do we already have pip?
   stat:


### PR DESCRIPTION
A recent update exposed that this won't work until the version is
updated in the AMI when an update is published.