### PR TITLE
Allow using alternative key names in git-crypt-*

### DIFF
--- a/roles/git-crypt-lock/defaults/main.yaml
+++ b/roles/git-crypt-lock/defaults/main.yaml
@@ -1,1 +1,2 @@
 git_crypt_repo: "{{ zuul.project.src_dir }}"
+git_crypt_key_name: ""

--- a/roles/git-crypt-lock/tasks/main.yaml
+++ b/roles/git-crypt-lock/tasks/main.yaml
@@ -1,6 +1,8 @@
 - name: Lock down the repo so we don't leave secrets behind
+  vars:
+    git_crypt_key_arg: "{% if git_crypt_key_name %}-k {{ git_crypt_key_name }} {% endif %}" 
   register: git_crypt_lock
   failed_when: false
-  command: git crypt lock
+  command: "git crypt lock {{ git_crypt_key_arg }}"
   args:
     chdir: "{{ git_crypt_repo }}"

--- a/roles/git-crypt-unlock/README.rst
+++ b/roles/git-crypt-unlock/README.rst
@@ -10,6 +10,12 @@ a repo that has been encrypted with `git-crypt`_.
    The secret key that will be used to unlock the repo. Must be a base64
    encoded ascii string.
 
+.. zuul:rolevar:: git_crypt_key_name
+   :default: ""
+
+   A string representing the name of the git-crypt key with which to unlock the
+   repo. If left blank, the default git-crypt key is used.
+
 .. zuul:rolevar:: git_crypt_repo
    :default: {{ zuul.project.src_dir }}
 

--- a/roles/git-crypt-unlock/defaults/main.yaml
+++ b/roles/git-crypt-unlock/defaults/main.yaml
@@ -1,2 +1,3 @@
 git_crypt_keystorage: /mnt/keystorage
+git_crypt_key_name: ""
 git_crypt_repo: "{{ zuul.project.src_dir }}"

--- a/roles/git-crypt-unlock/tasks/main.yaml
+++ b/roles/git-crypt-unlock/tasks/main.yaml
@@ -23,7 +23,9 @@
         mode: '0600'
         owner: "{{ ansible_user }}"
     - name: Unlock repo
-      command: git crypt unlock {{ git_crypt_keystorage }}/gitcrypt.key
+      vars:
+        git_crypt_key_arg: "{% if git_crypt_key_name %}-k {{ git_crypt_key_name }} {% endif %}" 
+      command: git crypt unlock {{ git_crypt_key_arg }}{{ git_crypt_keystorage }}/gitcrypt.key
       args:
         chdir: "{{ git_crypt_repo }}"
 #  always:


### PR DESCRIPTION
These are necessary for git-crypt to use multiple keys.