### PR TITLE
gitcrypt: do not pass -k to unlock

### DIFF
--- a/roles/git-crypt-unlock/README.rst
+++ b/roles/git-crypt-unlock/README.rst
@@ -10,12 +10,6 @@ a repo that has been encrypted with `git-crypt`_.
    The secret key that will be used to unlock the repo. Must be a base64
    encoded ascii string.
 
-.. zuul:rolevar:: git_crypt_key_name
-   :default: ""
-
-   A string representing the name of the git-crypt key with which to unlock the
-   repo. If left blank, the default git-crypt key is used.
-
 .. zuul:rolevar:: git_crypt_repo
    :default: {{ zuul.project.src_dir }}
 

--- a/roles/git-crypt-unlock/tasks/main.yaml
+++ b/roles/git-crypt-unlock/tasks/main.yaml
@@ -23,9 +23,7 @@
         mode: '0600'
         owner: "{{ ansible_user }}"
     - name: Unlock repo
-      vars:
-        git_crypt_key_arg: "{% if git_crypt_key_name %}-k {{ git_crypt_key_name }} {% endif %}" 
-      command: git crypt unlock {{ git_crypt_key_arg }}{{ git_crypt_keystorage }}/gitcrypt.key
+      command: git crypt unlock {{ git_crypt_keystorage }}/gitcrypt.key
       args:
         chdir: "{{ git_crypt_repo }}"
 #  always:


### PR DESCRIPTION
This doesn't actually work properly, the key file has its own name
stored inside. It is still needed for lock though.