### PR TITLE
Feat/assume role role

### DIFF
--- a/roles/aws-assume-role/tasks/main.yaml
+++ b/roles/aws-assume-role/tasks/main.yaml
@@ -6,8 +6,8 @@
 
 - name: Assume Role
   sts_assume_role:
-    role_arn: "arn:aws:iam::{{ aws_account_id }}:role/{{ role_name }}"
-    role_session_name: "{{ role_session_name }}"
+    role_arn: "arn:aws:iam::{{ aws_account_id }}:role/{{ aws_role_name }}"
+    role_session_name: "{{ aws_role_session_name }}"
     region: "{{ aws_region }}"
     aws_access_key: "{{ aws_credentials.access_key }}"
     aws_secret_key: "{{ aws_credentials.secret_key }}"


### PR DESCRIPTION
# Description

Fixes role-all-the-things bug caused by using reserved ansible variable name `role_name` for what is supposed to be the aws role name.